### PR TITLE
Remove Travis and update GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: tests
 on: [push, pull_request]
 jobs:
 
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.12
+    - name: Set up Go 1.16.x
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.16.x
       id: go
 
     - name: Check out code into the Go module directory
@@ -18,3 +18,24 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      if: success()
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Calc coverage
+      run: |
+        go test -v -covermode=count -coverprofile=coverage.out
+    - name: Convert coverage.out to coverage.lcov
+      uses: jandelgado/gcov2lcov-action@v1.0.6
+    - name: Coveralls
+      uses: coverallsapp/github-action@v1.1.2
+      with:
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-  language: go
-  go:
-    - master

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # fonet
 
-[![Build Status](https://travis-ci.org/Fontinalis/fonet.svg?branch=master)](https://travis-ci.org/Fontinalis/fonet)
+[![Go](https://github.com/Fontinalis/fonet/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/Fontinalis/fonet/actions/workflows/go.yml)
+[![Coverage Status](https://coveralls.io/repos/github/Fontinalis/fonet/badge.svg?branch=master)](https://coveralls.io/github/Fontinalis/fonet?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Fontinalis/fonet)](https://goreportcard.com/report/github.com/Fontinalis/fonet)
-[![GoDoc](https://godoc.org/github.com/Fontinalis/fonet?status.svg)](http://godoc.org/github.com/Fontinalis/fonet)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Fontinalis/fonet.svg)](https://pkg.go.dev/github.com/Fontinalis/fonet)
 
 `fonet` is a deep neural network package for Go. It's mainly created because I wanted to learn about neural networks and create my own package. I'm planning to continue the development of the package and add more function to it, for example exporting/importing a model.
 

--- a/examples/iris/go.mod
+++ b/examples/iris/go.mod
@@ -1,0 +1,10 @@
+module examples
+
+go 1.16
+
+replace github.com/pselle/bar => ../../
+
+require (
+	github.com/Fontinalis/fonet v0.0.0-20210601082414-1fd7135158c9
+	github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8
+)

--- a/examples/iris/go.sum
+++ b/examples/iris/go.sum
@@ -1,0 +1,4 @@
+github.com/Fontinalis/fonet v0.0.0-20210601082414-1fd7135158c9 h1:ctQfY8jQO93HXYIwPARnSQggjrZdNOB1TI6hn5K3mYU=
+github.com/Fontinalis/fonet v0.0.0-20210601082414-1fd7135158c9/go.mod h1:kW1TZAvBGU81UsyTc4/OvXS6rLIeI3OrnxSuKQprKbo=
+github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8 h1:hp1oqdzmv37vPLYFGjuM/RmUgUMfD9vQfMszc54l55Y=
+github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/Fontinalis/fonet
 
 go 1.16
-
-require github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8 h1:hp1oqdzmv37vPLYFGjuM/RmUgUMfD9vQfMszc54l55Y=
-github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=


### PR DESCRIPTION
Changes:
- removed Travis.org
- updated GitHub workflow
  - added Coveralls
  - updated to Go 1.16.x
- updated badges in README 